### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/labelzoom/labelzoom-moca-client-dotnet/security/code-scanning/6](https://github.com/labelzoom/labelzoom-moca-client-dotnet/security/code-scanning/6)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Based on the actions used in the workflow, the `contents: read` permission is sufficient for most steps, as they involve checking out code, setting up .NET, and uploading artifacts. If any step requires additional permissions, they can be added to the `permissions` block.

The `permissions` block should be added after the `name` field (line 4) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
