### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,5 +1,8 @@
 name: Publish NuGet Package
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/labelzoom/labelzoom-moca-client-dotnet/security/code-scanning/7](https://github.com/labelzoom/labelzoom-moca-client-dotnet/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with repository contents (e.g., restoring dependencies, building, and publishing packages). Therefore, the `contents: read` permission is sufficient. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
